### PR TITLE
docs: document sdk setup and pipeline overview

### DIFF
--- a/docs/android-sdk-setup-and-testing.md
+++ b/docs/android-sdk-setup-and-testing.md
@@ -1,27 +1,25 @@
 # Android SDK Setup and Test Execution Notes
 
-This document captures the exact steps used to provision the Android SDK in the CI container environment and to execute the existing unit test suite for the project. It is intended to help other engineers reproduce the setup quickly and to highlight any noteworthy observations from the run.
+This document captures the exact steps used to provision the Android SDK in the containerized workspace and to execute the project's unit test suite. It is intended to help other engineers reproduce the setup quickly and to highlight any noteworthy observations from the run.
 
 ## Environment
 
-- **Host OS:** Debian-based container image (as provided by the execution environment)
-- **Java runtime:** Managed by Gradle wrapper (automatically downloads the toolchain declared in the build)
+- **Host OS:** Debian-based container image supplied by the execution environment
+- **Java runtime:** OpenJDK 21.0.2 (matches the version required by Android Gradle Plugin 8.13.0)
 - **Android SDK location:** `$HOME/android-sdk`
 
 ## SDK Installation Steps
 
-1. **Download the Android command-line tools.**
+1. **Create the SDK directory and download the command-line tools.**
    ```bash
-   mkdir -p "$HOME/android-sdk"
+   mkdir -p "$HOME/android-sdk/cmdline-tools"
    cd "$HOME/android-sdk"
    wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
-   unzip commandlinetools-linux-11076708_latest.zip -d cmdline-tools-temp
-   mkdir -p cmdline-tools/latest
-   mv cmdline-tools-temp/cmdline-tools/* cmdline-tools/latest/
-   rm -rf cmdline-tools-temp commandlinetools-linux-11076708_latest.zip
+   unzip commandlinetools-linux-11076708_latest.zip -d cmdline-tools
+   mv cmdline-tools/cmdline-tools cmdline-tools/latest
    ```
 
-2. **Export the required environment variables (add to your shell profile for reuse).**
+2. **Export the required environment variables (add them to your shell profile for reuse).**
    ```bash
    export ANDROID_HOME="$HOME/android-sdk"
    export ANDROID_SDK_ROOT="$ANDROID_HOME"
@@ -38,16 +36,16 @@ This document captures the exact steps used to provision the Android SDK in the 
 
 ## Test Execution
 
-Run the unit tests from the project root once the SDK is configured:
+Run the JVM unit tests from the project root once the SDK is configured:
 
 ```bash
-./gradlew testDebugUnitTest --console=plain
+./gradlew test --console=plain
 ```
 
 ### Result Summary
 
 - Status: **PASS**
-- Build duration: ~1 minute 21 seconds on the reference container
+- Build duration: ~1 minute 20 seconds on the reference container
 - Notable output: Gradle downloaded Android SDK Build-Tools 35.0.0 on-demand to satisfy the build configuration.
 
 The successful completion of the task confirms that the Android SDK installation is functional and that the unit tests pass with the current source code.
@@ -55,7 +53,6 @@ The successful completion of the task confirms that the Android SDK installation
 ## Troubleshooting Tips
 
 - If the `sdkmanager` command is not found, ensure the `cmdline-tools/latest/bin` directory is at the front of your `PATH`.
-- When running inside a clean container, remember that accepting the SDK licenses requires interactive input. Prepending `yes |` to the `sdkmanager` command handles this automatically.
+- When running inside a clean container, accepting the SDK licenses requires interactive input. Prepending `yes |` to the `sdkmanager` command handles this automatically.
 - Gradle may request older build-tools versions. Allow it to download the additional packages or install them explicitly with `sdkmanager` if network restrictions apply.
 - Should tests fail due to missing emulator/device dependencies, verify that only unit tests (not instrumentation tests) are being executed. The `testDebugUnitTest` task runs on the JVM and does not require an Android device.
-

--- a/docs/video-to-gif-module-overview.md
+++ b/docs/video-to-gif-module-overview.md
@@ -1,0 +1,21 @@
+# Video-to-GIF Workflow Overview
+
+The application logic lives in `MainActivity.kt` and is implemented with Jetpack Compose and FFmpegKit. This document summarizes the main responsibilities of each composable and helper routine to help new engineers navigate the codebase quickly.
+
+## UI Layer (Jetpack Compose)
+
+- **`VideoToGifApp`** orchestrates the user flow: video selection, conversion trigger, GIF preview, and save-to-gallery action. It also owns the state for log visibility, progress indication, and error messaging. The composable wires up an `ActivityResultLauncher` that clears previous state each time a new video is selected, ensuring stale status messages are not shown to the user.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L81-L137】【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L140-L209】
+- **`VideoPreview`** hosts a traditional `VideoView` inside Compose via `AndroidView` to provide playback controls. It guards against repeated error reporting, loops the video for continuous preview, and gracefully handles URI changes by resetting playback listeners.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L211-L315】
+- **`GifPreview`** uses Coil with GIF support to render the generated file, ensuring the preview is clipped and scaled appropriately inside a square aspect ratio container.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L317-L337】
+
+## Conversion Pipeline
+
+- **`convertVideoToGif`** runs on a background `CoroutineScope` tied to a `SupervisorJob` and the IO dispatcher. It validates the input using `extractVideoMetadata`, caches the video locally, and builds a deterministic FFmpeg command (`fps=10`, Lanczos scaling to width 320). Logs and callbacks are marshalled back to the main thread with a `Handler`, so UI state updates remain thread-safe.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L339-L448】【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L454-L517】
+- **`createTempFileFromUri`** copies the selected video into the app's cache directory with a sanitized extension and explicit `fsync` attempt. It validates that the cached file exists and has non-zero length before proceeding, surfacing descriptive IO errors to the logs if anything fails.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L519-L560】
+
+## Persistence Utilities
+
+- **`saveGifToGallery`** writes the generated GIF into MediaStore, supporting both pre- and post-Android Q semantics. It marks pending entries on modern Android versions, updates the row to clear the pending flag when the copy completes, and returns the resulting `Uri` to the caller.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L384-L436】
+- **`getFileName`, `getFileExtensionFromUri`** and other metadata helpers centralize querying `ContentResolver` for user-friendly details. This avoids scattering cursor-handling logic throughout the UI layer.【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L438-L517】【F:app/src/main/java/com/example/giffer2/MainActivity.kt†L562-L609】
+
+Understanding these building blocks should make it easier to extend the pipeline—for example, to expose frame-rate controls, alternative scaling profiles, or richer error reporting.


### PR DESCRIPTION
## Summary
- update the Android SDK installation guide with the exact commands executed in the workspace
- capture the unit test invocation details and add troubleshooting notes for future runs
- document the main Compose UI and FFmpeg pipeline components to orient new contributors

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e0693209b8832082a35d9fcea1b665