### PR TITLE
Add GifVision effect settings and work tracking models

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -8,4 +8,5 @@ kotlin {
 
 dependencies {
     // Kotlin stdlib is added automatically; additional dependencies can be declared here when needed.
+    implementation(libs.androidx.work.runtime.ktx)
 }

--- a/core/model/src/main/kotlin/com/example/gifvision/EffectSettings.kt
+++ b/core/model/src/main/kotlin/com/example/gifvision/EffectSettings.kt
@@ -1,0 +1,235 @@
+package com.example.gifvision
+
+/** Metadata extracted from a source clip used to seed effect defaults. */
+data class ClipMetadata(
+    val width: Int?,
+    val height: Int?,
+    val durationMillis: Long?,
+    val frameRate: Double?
+) {
+    val aspectRatio: Float? = if (width != null && height != null && height != 0) {
+        width.toFloat() / height.toFloat()
+    } else {
+        null
+    }
+}
+
+/** Range of the source clip to render. */
+data class ClipTrim(
+    val startMs: Long = 0,
+    val endMs: Long? = null
+) {
+    init {
+        require(startMs >= 0) { "Clip trim start must be non-negative." }
+        require(endMs == null || endMs >= startMs) { "Clip trim end must be >= start." }
+    }
+
+    val durationMs: Long?
+        get() = endMs?.let { it - startMs }
+
+    fun withDuration(durationMs: Long?): ClipTrim = copy(endMs = durationMs?.let { startMs + it })
+
+    companion object {
+        val FULL = ClipTrim()
+    }
+}
+
+/** Configuration for text overlays applied to a stream. */
+data class TextOverlay(
+    val text: String = "",
+    val fontSizeSp: Int = DEFAULT_FONT_SIZE_SP,
+    val colorArgb: Int = DEFAULT_COLOR,
+    val enabled: Boolean = false
+) {
+    companion object {
+        const val DEFAULT_FONT_SIZE_SP = 18
+        const val DEFAULT_COLOR: Int = 0xFFFFFFFF.toInt()
+    }
+}
+
+/** Color balance multipliers applied to the stream. */
+data class RgbBalance(
+    val red: Float = 1f,
+    val green: Float = 1f,
+    val blue: Float = 1f
+) {
+    fun clamp(): RgbBalance = copy(
+        red = red.coerceAtLeast(0f),
+        green = green.coerceAtLeast(0f),
+        blue = blue.coerceAtLeast(0f)
+    )
+}
+
+/**
+ * Aggregates every user-controlled adjustment surfaced in the GifVision manual.
+ */
+data class EffectSettings(
+    val streamId: StreamId,
+    val resolutionPercent: Int,
+    val maxColors: Int,
+    val frameRate: Double,
+    val clipTrim: ClipTrim,
+    val textOverlay: TextOverlay,
+    val brightness: Float,
+    val contrast: Float,
+    val saturation: Float,
+    val hue: Float,
+    val sepia: Boolean,
+    val rgbBalance: RgbBalance,
+    val chromaWarp: Boolean,
+    val colorCycleSpeed: Float,
+    val motionTrails: Boolean,
+    val sharpen: Boolean,
+    val edgeDetect: Boolean,
+    val negate: Boolean,
+    val flipHorizontal: Boolean,
+    val flipVertical: Boolean
+) {
+    fun resetForNewSource(metadata: ClipMetadata): EffectSettings {
+        val defaults = defaultSettings(streamId)
+        val duration = metadata.durationMillis
+        val frameRateGuess = metadata.frameRate ?: defaults.frameRate
+        return defaults.copy(
+            frameRate = frameRateGuess,
+            clipTrim = ClipTrim(startMs = 0, endMs = duration),
+            resolutionPercent = Companion.computeResolutionPercent(metadata) ?: defaults.resolutionPercent
+        )
+    }
+
+    fun toWorkData(): androidx.work.Data {
+        val builder = androidx.work.Data.Builder()
+            .putInt(KEY_STREAM, streamId.toWorkValue())
+            .putInt(KEY_RESOLUTION_PERCENT, resolutionPercent)
+            .putInt(KEY_MAX_COLORS, maxColors)
+            .putDouble(KEY_FRAME_RATE, frameRate)
+            .putLong(KEY_CLIP_START_MS, clipTrim.startMs)
+            .putBoolean(KEY_TEXT_ENABLED, textOverlay.enabled)
+            .putString(KEY_TEXT_VALUE, textOverlay.text)
+            .putInt(KEY_TEXT_FONT_SIZE, textOverlay.fontSizeSp)
+            .putInt(KEY_TEXT_COLOR, textOverlay.colorArgb)
+            .putFloat(KEY_BRIGHTNESS, brightness)
+            .putFloat(KEY_CONTRAST, contrast)
+            .putFloat(KEY_SATURATION, saturation)
+            .putFloat(KEY_HUE, hue)
+            .putBoolean(KEY_SEPIA, sepia)
+            .putFloat(KEY_RGB_RED, rgbBalance.red)
+            .putFloat(KEY_RGB_GREEN, rgbBalance.green)
+            .putFloat(KEY_RGB_BLUE, rgbBalance.blue)
+            .putBoolean(KEY_CHROMA_WARP, chromaWarp)
+            .putFloat(KEY_COLOR_CYCLE_SPEED, colorCycleSpeed)
+            .putBoolean(KEY_MOTION_TRAILS, motionTrails)
+            .putBoolean(KEY_SHARPEN, sharpen)
+            .putBoolean(KEY_EDGE_DETECT, edgeDetect)
+            .putBoolean(KEY_NEGATE, negate)
+            .putBoolean(KEY_FLIP_HORIZONTAL, flipHorizontal)
+            .putBoolean(KEY_FLIP_VERTICAL, flipVertical)
+
+        clipTrim.endMs?.let { builder.putLong(KEY_CLIP_END_MS, it) }
+        return builder.build()
+    }
+
+    companion object {
+        private const val KEY_STREAM = "effect.stream"
+        private const val KEY_RESOLUTION_PERCENT = "effect.resolution"
+        private const val KEY_MAX_COLORS = "effect.maxColors"
+        private const val KEY_FRAME_RATE = "effect.frameRate"
+        private const val KEY_CLIP_START_MS = "effect.clip.start"
+        private const val KEY_CLIP_END_MS = "effect.clip.end"
+        private const val KEY_TEXT_ENABLED = "effect.text.enabled"
+        private const val KEY_TEXT_VALUE = "effect.text.value"
+        private const val KEY_TEXT_FONT_SIZE = "effect.text.fontSize"
+        private const val KEY_TEXT_COLOR = "effect.text.color"
+        private const val KEY_BRIGHTNESS = "effect.brightness"
+        private const val KEY_CONTRAST = "effect.contrast"
+        private const val KEY_SATURATION = "effect.saturation"
+        private const val KEY_HUE = "effect.hue"
+        private const val KEY_SEPIA = "effect.sepia"
+        private const val KEY_RGB_RED = "effect.rgb.red"
+        private const val KEY_RGB_GREEN = "effect.rgb.green"
+        private const val KEY_RGB_BLUE = "effect.rgb.blue"
+        private const val KEY_CHROMA_WARP = "effect.chromaWarp"
+        private const val KEY_COLOR_CYCLE_SPEED = "effect.colorCycleSpeed"
+        private const val KEY_MOTION_TRAILS = "effect.motionTrails"
+        private const val KEY_SHARPEN = "effect.sharpen"
+        private const val KEY_EDGE_DETECT = "effect.edgeDetect"
+        private const val KEY_NEGATE = "effect.negate"
+        private const val KEY_FLIP_HORIZONTAL = "effect.flipHorizontal"
+        private const val KEY_FLIP_VERTICAL = "effect.flipVertical"
+
+        internal val DEFAULT_FRAME_RATE = 12.0
+        internal const val DEFAULT_MAX_COLORS = 256
+        internal const val DEFAULT_RESOLUTION_PERCENT = 100
+
+        fun defaultSettings(stream: StreamId): EffectSettings = EffectSettings(
+            streamId = stream,
+            resolutionPercent = DEFAULT_RESOLUTION_PERCENT,
+            maxColors = DEFAULT_MAX_COLORS,
+            frameRate = DEFAULT_FRAME_RATE,
+            clipTrim = ClipTrim.FULL,
+            textOverlay = TextOverlay(),
+            brightness = 0f,
+            contrast = 1f,
+            saturation = 1f,
+            hue = 0f,
+            sepia = false,
+            rgbBalance = RgbBalance(),
+            chromaWarp = false,
+            colorCycleSpeed = 0f,
+            motionTrails = false,
+            sharpen = false,
+            edgeDetect = false,
+            negate = false,
+            flipHorizontal = false,
+            flipVertical = false
+        )
+
+        fun fromWorkData(data: androidx.work.Data): EffectSettings {
+            val defaultPacked = StreamId.of(LayerId.Layer1, StreamChannel.A).toWorkValue()
+            val stream = StreamId.fromWorkValue(data.getInt(KEY_STREAM, defaultPacked))
+            return defaultSettings(stream).copy(
+                resolutionPercent = data.getInt(KEY_RESOLUTION_PERCENT, DEFAULT_RESOLUTION_PERCENT),
+                maxColors = data.getInt(KEY_MAX_COLORS, DEFAULT_MAX_COLORS),
+                frameRate = data.getDouble(KEY_FRAME_RATE, DEFAULT_FRAME_RATE),
+                clipTrim = ClipTrim(
+                    startMs = data.getLong(KEY_CLIP_START_MS, 0L),
+                    endMs = data.getLong(KEY_CLIP_END_MS, -1L).takeIf { it >= 0 }
+                ),
+                textOverlay = TextOverlay(
+                    text = data.getString(KEY_TEXT_VALUE).orEmpty(),
+                    fontSizeSp = data.getInt(KEY_TEXT_FONT_SIZE, TextOverlay.DEFAULT_FONT_SIZE_SP),
+                    colorArgb = data.getInt(KEY_TEXT_COLOR, TextOverlay.DEFAULT_COLOR),
+                    enabled = data.getBoolean(KEY_TEXT_ENABLED, false)
+                ),
+                brightness = data.getFloat(KEY_BRIGHTNESS, 0f),
+                contrast = data.getFloat(KEY_CONTRAST, 1f),
+                saturation = data.getFloat(KEY_SATURATION, 1f),
+                hue = data.getFloat(KEY_HUE, 0f),
+                sepia = data.getBoolean(KEY_SEPIA, false),
+                rgbBalance = RgbBalance(
+                    red = data.getFloat(KEY_RGB_RED, 1f),
+                    green = data.getFloat(KEY_RGB_GREEN, 1f),
+                    blue = data.getFloat(KEY_RGB_BLUE, 1f)
+                ),
+                chromaWarp = data.getBoolean(KEY_CHROMA_WARP, false),
+                colorCycleSpeed = data.getFloat(KEY_COLOR_CYCLE_SPEED, 0f),
+                motionTrails = data.getBoolean(KEY_MOTION_TRAILS, false),
+                sharpen = data.getBoolean(KEY_SHARPEN, false),
+                edgeDetect = data.getBoolean(KEY_EDGE_DETECT, false),
+                negate = data.getBoolean(KEY_NEGATE, false),
+                flipHorizontal = data.getBoolean(KEY_FLIP_HORIZONTAL, false),
+                flipVertical = data.getBoolean(KEY_FLIP_VERTICAL, false)
+            )
+        }
+
+        internal fun computeResolutionPercent(metadata: ClipMetadata): Int? {
+            val targetWidth = metadata.width ?: return null
+            return when {
+                targetWidth >= 1920 -> 50
+                targetWidth >= 1280 -> 75
+                else -> DEFAULT_RESOLUTION_PERCENT
+            }
+        }
+
+    }
+}
+

--- a/core/model/src/main/kotlin/com/example/gifvision/GifWorkModels.kt
+++ b/core/model/src/main/kotlin/com/example/gifvision/GifWorkModels.kt
@@ -1,0 +1,159 @@
+package com.example.gifvision
+
+import androidx.work.Data
+import java.util.UUID
+
+/** Severity levels emitted by FFmpeg and surfaced to the UI. */
+enum class LogSeverity { INFO, WARNING, ERROR }
+
+/** Structured log entry forwarded to the GifVision log console. */
+data class LogEntry(
+    val message: String,
+    val severity: LogSeverity = LogSeverity.INFO,
+    val timestampMillis: Long = System.currentTimeMillis(),
+    val workId: UUID? = null
+)
+
+/**
+ * Snapshot of an end-to-end GIF render request. The blueprint keeps the render inputs together so
+ * scheduling, logging, and retry logic can reuse a single identifier.
+ */
+data class GifTranscodeBlueprint(
+    val blueprintId: UUID,
+    val streamId: StreamId,
+    val source: GifReference,
+    val effectSettings: EffectSettings,
+    val blendMode: BlendMode = BlendMode.Normal,
+    val blendOpacity: Float = 1f,
+    val requestedAtMillis: Long = System.currentTimeMillis()
+) {
+    fun toWorkData(): Data {
+        val builder = Data.Builder()
+            .putString(KEY_BLUEPRINT_ID, blueprintId.toString())
+            .putInt(KEY_STREAM, streamId.toWorkValue())
+            .putString(KEY_BLEND_MODE, blendMode.name)
+            .putFloat(KEY_BLEND_OPACITY, blendOpacity)
+            .putLong(KEY_REQUESTED_AT, requestedAtMillis)
+            .putAll(effectSettings.toWorkData())
+
+        when (source) {
+            is GifReference.FileUri -> builder
+                .putString(KEY_SOURCE_TYPE, SOURCE_FILE_URI)
+                .putString(KEY_SOURCE_VALUE, source.uri)
+            is GifReference.ContentUri -> builder
+                .putString(KEY_SOURCE_TYPE, SOURCE_CONTENT_URI)
+                .putString(KEY_SOURCE_VALUE, source.uri)
+            is GifReference.InMemory -> builder
+                .putString(KEY_SOURCE_TYPE, SOURCE_IN_MEMORY)
+                .putByteArray(KEY_SOURCE_BYTES, source.bytes)
+                .putString(KEY_SOURCE_NAME_HINT, source.fileNameHint)
+        }
+
+        return builder.build()
+    }
+
+    companion object {
+        private const val KEY_BLUEPRINT_ID = "blueprint.id"
+        private const val KEY_STREAM = "blueprint.stream"
+        private const val KEY_SOURCE_TYPE = "blueprint.source.type"
+        private const val KEY_SOURCE_VALUE = "blueprint.source.value"
+        private const val KEY_SOURCE_BYTES = "blueprint.source.bytes"
+        private const val KEY_SOURCE_NAME_HINT = "blueprint.source.name"
+        private const val KEY_BLEND_MODE = "blueprint.blend.mode"
+        private const val KEY_BLEND_OPACITY = "blueprint.blend.opacity"
+        private const val KEY_REQUESTED_AT = "blueprint.requestedAt"
+
+        private const val SOURCE_FILE_URI = "file_uri"
+        private const val SOURCE_CONTENT_URI = "content_uri"
+        private const val SOURCE_IN_MEMORY = "in_memory"
+
+        fun fromWorkData(data: Data): GifTranscodeBlueprint {
+            val blueprintId = UUID.fromString(data.getString(KEY_BLUEPRINT_ID))
+            val stream = StreamId.fromWorkValue(data.getInt(KEY_STREAM, 0))
+            val effect = EffectSettings.fromWorkData(data)
+            val blendMode = BlendMode.valueOf(data.getString(KEY_BLEND_MODE) ?: BlendMode.Normal.name)
+            val opacity = data.getFloat(KEY_BLEND_OPACITY, 1f)
+            val requestedAt = data.getLong(KEY_REQUESTED_AT, System.currentTimeMillis())
+            val source = when (data.getString(KEY_SOURCE_TYPE)) {
+                SOURCE_FILE_URI -> GifReference.FileUri(data.getString(KEY_SOURCE_VALUE)!!)
+                SOURCE_CONTENT_URI -> GifReference.ContentUri(data.getString(KEY_SOURCE_VALUE)!!)
+                SOURCE_IN_MEMORY -> GifReference.InMemory(
+                    bytes = data.getByteArray(KEY_SOURCE_BYTES) ?: ByteArray(0),
+                    fileNameHint = data.getString(KEY_SOURCE_NAME_HINT)
+                )
+                else -> error("Missing source type for blueprint ${blueprintId}")
+            }
+
+            return GifTranscodeBlueprint(
+                blueprintId = blueprintId,
+                streamId = stream,
+                source = source,
+                effectSettings = effect,
+                blendMode = blendMode,
+                blendOpacity = opacity,
+                requestedAtMillis = requestedAt
+            )
+        }
+
+        fun sampleBlueprint(streamId: StreamId = StreamId.of(LayerId.Layer1, StreamChannel.A)): GifTranscodeBlueprint {
+            val effectDefaults = EffectSettings.defaultSettings(streamId)
+            val inMemory = GifReference.InMemory(byteArrayOf(), fileNameHint = "sample.gif")
+            return GifTranscodeBlueprint(
+                blueprintId = UUID.randomUUID(),
+                streamId = streamId,
+                source = inMemory,
+                effectSettings = effectDefaults
+            )
+        }
+    }
+}
+
+/**
+ * Models the coarse progress reported by workers so progress bars can animate consistently between
+ * queueing and completion.
+ */
+data class GifWorkProgress(
+    val workId: UUID,
+    val percent: Int,
+    val stage: Stage
+) {
+    init {
+        require(percent in 0..100) { "Progress percent must be between 0 and 100." }
+    }
+
+    fun toData(): Data = Data.Builder()
+        .putString(KEY_WORK_ID, workId.toString())
+        .putInt(KEY_PERCENT, percent)
+        .putString(KEY_STAGE, stage.name)
+        .build()
+
+    enum class Stage { QUEUED, PREPARING, PALETTE, RENDERING, BLENDING, COMPLETED }
+
+    companion object {
+        private const val KEY_WORK_ID = "progress.workId"
+        private const val KEY_PERCENT = "progress.percent"
+        private const val KEY_STAGE = "progress.stage"
+
+        fun fromData(data: Data): GifWorkProgress {
+            val workId = data.getString(KEY_WORK_ID)?.let(UUID::fromString)
+                ?: error("Work id missing from progress payload")
+            val percent = data.getInt(KEY_PERCENT, 0)
+            val stage = data.getString(KEY_STAGE)?.let { Stage.valueOf(it) } ?: Stage.QUEUED
+            return GifWorkProgress(workId, percent, stage)
+        }
+    }
+}
+
+/** Tracks the relationship between a blueprint, a WorkManager id, and the latest progress. */
+data class GifWorkTracker(
+    val blueprint: GifTranscodeBlueprint,
+    val workId: UUID,
+    val latestProgress: GifWorkProgress = GifWorkProgress(workId, percent = 0, stage = GifWorkProgress.Stage.QUEUED),
+    val isComplete: Boolean = false
+) {
+    fun update(progress: GifWorkProgress): GifWorkTracker = copy(
+        latestProgress = progress,
+        isComplete = progress.stage == GifWorkProgress.Stage.COMPLETED || progress.percent == 100
+    )
+}
+

--- a/core/model/src/main/kotlin/com/example/gifvision/Identifiers.kt
+++ b/core/model/src/main/kotlin/com/example/gifvision/Identifiers.kt
@@ -1,0 +1,130 @@
+package com.example.gifvision
+
+/**
+ * Identifies one of the two GifVision layers. Layers are addressed using 1-based indices so
+ * their human readable labels match the copy surfaced in the manual and UI.
+ */
+@JvmInline
+value class LayerId private constructor(val index: Int) : Comparable<LayerId> {
+    init {
+        require(index in MIN_INDEX..MAX_INDEX) {
+            "Layer index must be between $MIN_INDEX and $MAX_INDEX (inclusive)."
+        }
+    }
+
+    /** Display label used by UI and logging. */
+    val displayName: String = "Layer $index"
+
+    override fun compareTo(other: LayerId): Int = index.compareTo(other.index)
+
+    override fun toString(): String = displayName
+
+    companion object {
+        const val MIN_INDEX = 1
+        const val MAX_INDEX = 2
+
+        val Layer1: LayerId = LayerId(1)
+        val Layer2: LayerId = LayerId(2)
+
+        val All: List<LayerId> = listOf(Layer1, Layer2)
+
+        fun of(index: Int): LayerId = when (index) {
+            1 -> Layer1
+            2 -> Layer2
+            else -> throw IllegalArgumentException("Unsupported layer index: $index")
+        }
+    }
+}
+
+/** Identifies which stream inside a layer is being referenced (Stream A or Stream B). */
+enum class StreamChannel(val displayName: String) {
+    A("Stream A"),
+    B("Stream B");
+
+    override fun toString(): String = displayName
+}
+
+/**
+ * Value class packing the layer index and stream channel into a single stable identifier.
+ * This keeps WorkManager serialization compact while preserving type safety in Kotlin.
+ */
+@JvmInline
+value class StreamId internal constructor(private val packed: Int) {
+
+    val layer: LayerId
+        get() = LayerId.of(packed shr SHIFT_BITS)
+
+    val channel: StreamChannel
+        get() = if ((packed and CHANNEL_MASK) == StreamChannel.A.ordinal) {
+            StreamChannel.A
+        } else {
+            StreamChannel.B
+        }
+
+    val displayName: String = "${layer.displayName} ${channel.displayName}"
+
+    override fun toString(): String = displayName
+
+    fun toWorkValue(): Int = packed
+
+    companion object {
+        private const val SHIFT_BITS = 1
+        private const val CHANNEL_MASK = 0x01
+
+        fun of(layerId: LayerId, channel: StreamChannel): StreamId {
+            val layerBits = layerId.index shl SHIFT_BITS
+            val channelBits = if (channel == StreamChannel.A) 0 else 1
+            return StreamId(layerBits or channelBits)
+        }
+
+        fun fromWorkValue(value: Int): StreamId {
+            val layerBits = value shr SHIFT_BITS
+            require(layerBits in LayerId.MIN_INDEX..LayerId.MAX_INDEX) {
+                "Invalid packed stream id: $value"
+            }
+            return StreamId(value)
+        }
+    }
+}
+
+/** Blend modes supported by GifVision's layer and stream compositors. */
+enum class BlendMode(val displayName: String, val ffmpegToken: String) {
+    Normal("Normal", "normal"),
+    Multiply("Multiply", "multiply"),
+    Screen("Screen", "screen"),
+    Overlay("Overlay", "overlay"),
+    Darken("Darken", "darken"),
+    Lighten("Lighten", "lighten"),
+    Difference("Difference", "difference"),
+    Addition("Addition", "addition"),
+    Subtract("Subtract", "subtract");
+
+    override fun toString(): String = displayName
+
+    companion object {
+        fun fromToken(token: String): BlendMode = entries.firstOrNull {
+            it.name.equals(token, ignoreCase = true) || it.ffmpegToken.equals(token, ignoreCase = true)
+        } ?: throw IllegalArgumentException("Unknown blend mode token: $token")
+    }
+}
+
+/**
+ * References to GIF payloads. These abstractions make it easy to pass file-, content-, or
+ * in-memory sources between the UI layer and WorkManager workers.
+ */
+sealed interface GifReference {
+    val label: String
+
+    data class FileUri(val uri: String) : GifReference {
+        override val label: String = uri
+    }
+
+    data class ContentUri(val uri: String) : GifReference {
+        override val label: String = uri
+    }
+
+    data class InMemory(val bytes: ByteArray, val fileNameHint: String? = null) : GifReference {
+        override val label: String = fileNameHint ?: "in_memory.gif"
+    }
+}
+


### PR DESCRIPTION
## Summary
- add layer and stream identifiers, blend modes, and GIF reference abstractions shared with the UI
- implement EffectSettings with defaults/reset helpers and WorkManager serialization hooks
- introduce GIF transcode blueprints, work progress/tracker models, and FFmpeg log entries for UI consumption

## Testing
- ./gradlew test *(fails: Android SDK path not configured in container)*
- ./gradlew :core:model:compileKotlin *(fails: JDK 11 toolchain download repositories unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e07a3d587c832084b20eee695b37ea