### PR TITLE
Add FFmpeg command runner and filter graph builder

### DIFF
--- a/core/ffmpeg/build.gradle.kts
+++ b/core/ffmpeg/build.gradle.kts
@@ -25,4 +25,7 @@ dependencies {
     implementation("com.arthenica:ffmpeg-kit-https:6.0-2.LTS")
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.junit)
 }

--- a/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/FfmpegKitCommandRunner.kt
+++ b/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/FfmpegKitCommandRunner.kt
@@ -1,0 +1,86 @@
+package com.example.gifvision.ffmpeg
+
+import com.arthenica.ffmpegkit.ExecuteCallback
+import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.FFmpegSession
+import com.arthenica.ffmpegkit.Level
+import com.arthenica.ffmpegkit.Log
+import com.arthenica.ffmpegkit.LogCallback
+import com.arthenica.ffmpegkit.Statistics
+import com.arthenica.ffmpegkit.StatisticsCallback
+import java.util.Locale
+
+/**
+ * Thin wrapper around [FFmpegKit.executeAsync] that exposes typed callbacks for the
+ * GifVision worker layer.
+ */
+class FfmpegKitCommandRunner(
+    private val adapter: FfmpegKitAdapter = FfmpegKitAdapter.Default
+) {
+
+    data class Callbacks(
+        val onStdout: (String) -> Unit = {},
+        val onStderr: (String) -> Unit = {},
+        val onStatistics: (Statistics) -> Unit = {},
+        val onComplete: (FFmpegSession) -> Unit = {}
+    )
+
+    fun execute(command: String, callbacks: Callbacks = Callbacks()): FFmpegSession {
+        return adapter.executeAsync(
+            command = command,
+            complete = ExecuteCallback { session ->
+                callbacks.onComplete(session)
+            },
+            log = LogCallback { log ->
+                handleLog(log, callbacks)
+            },
+            statistics = StatisticsCallback { statistics ->
+                callbacks.onStatistics(statistics)
+            }
+        )
+    }
+
+    private fun handleLog(log: Log?, callbacks: Callbacks) {
+        val message = log?.message?.trimEnd()?.takeIf { it.isNotEmpty() } ?: return
+        val level = log.level
+        if (isStderrLevel(level)) {
+            callbacks.onStderr(message)
+        } else {
+            callbacks.onStdout(message)
+        }
+    }
+
+    private fun isStderrLevel(level: Level?): Boolean {
+        if (level == null) {
+            return false
+        }
+        return when (level) {
+            Level.AV_LOG_PANIC,
+            Level.AV_LOG_FATAL,
+            Level.AV_LOG_ERROR,
+            Level.AV_LOG_WARNING -> true
+            else -> level.name.lowercase(Locale.US).contains("error") ||
+                level.name.lowercase(Locale.US).contains("stderr")
+        }
+    }
+
+    fun interface FfmpegKitAdapter {
+        fun executeAsync(
+            command: String,
+            complete: ExecuteCallback,
+            log: LogCallback,
+            statistics: StatisticsCallback
+        ): FFmpegSession
+
+        object Default : FfmpegKitAdapter {
+            override fun executeAsync(
+                command: String,
+                complete: ExecuteCallback,
+                log: LogCallback,
+                statistics: StatisticsCallback
+            ): FFmpegSession {
+                return FFmpegKit.executeAsync(command, complete, log, statistics)
+            }
+        }
+    }
+}

--- a/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/FilterGraphBuilder.kt
+++ b/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/FilterGraphBuilder.kt
@@ -1,0 +1,184 @@
+package com.example.gifvision.ffmpeg
+
+import com.example.gifvision.BlendMode
+import com.example.gifvision.EffectSettings
+import com.example.gifvision.GifTranscodeBlueprint
+import com.example.gifvision.RgbBalance
+import com.example.gifvision.TextOverlay
+import java.util.Locale
+import kotlin.math.abs
+
+class FilterGraphBuilder {
+
+    data class StreamGraphs(
+        val baseFilters: List<String>,
+        val paletteFilters: List<String>,
+        val renderFilters: List<String>
+    ) {
+        val baseGraph: String = baseFilters.joinToString(",")
+        val paletteGraph: String = paletteFilters.joinToString(",")
+        val renderGraph: String = renderFilters.joinToString(",")
+    }
+
+    fun buildStreamGraphs(
+        blueprint: GifTranscodeBlueprint,
+        effectSettings: EffectSettings = blueprint.effectSettings
+    ): StreamGraphs {
+        val baseFilters = buildBaseFilters(effectSettings)
+        val paletteFilters = baseFilters + buildPaletteFilter(effectSettings)
+        val renderFilters = baseFilters + buildPaletteUseFilter()
+        return StreamGraphs(baseFilters, paletteFilters, renderFilters)
+    }
+
+    fun buildBlendGraph(blendMode: BlendMode, opacity: Float): String {
+        val clampedOpacity = opacity.coerceIn(0f, 1f)
+        return "[0:v][1:v]blend=all_mode=${blendMode.ffmpegToken}:all_opacity=${formatDecimal(clampedOpacity.toDouble())},format=rgba"
+    }
+
+    private fun buildBaseFilters(effectSettings: EffectSettings): List<String> {
+        val filters = mutableListOf<String>()
+        buildTrimFilter(effectSettings)?.let(filters::add)
+        filters.add("setpts=PTS-STARTPTS")
+        filters.add("fps=${formatDecimal(effectSettings.frameRate)}")
+        filters.add(buildScaleFilter(effectSettings.resolutionPercent))
+        filters.add(buildEqFilter(effectSettings))
+        buildColorBalanceFilter(effectSettings.rgbBalance)?.let(filters::add)
+        buildHueFilter(effectSettings.hue)?.let(filters::add)
+        if (effectSettings.sepia) {
+            filters.add(SEPIA_FILTER)
+        }
+        if (effectSettings.chromaWarp) {
+            filters.add("chromashift=cb=5:cr=-5")
+        }
+        if (!isApproximatelyZero(effectSettings.colorCycleSpeed)) {
+            filters.add("hue='H+${formatDecimal(effectSettings.colorCycleSpeed.toDouble())}*t'")
+        }
+        if (effectSettings.motionTrails) {
+            filters.add("tmix=frames=3:weights='1 1 1'")
+        }
+        if (effectSettings.sharpen) {
+            filters.add("unsharp=5:5:1.0:5:5:0.0")
+        }
+        if (effectSettings.edgeDetect) {
+            filters.add("edgedetect=mode=colormix:high=0.2:low=0.1")
+        }
+        if (effectSettings.negate) {
+            filters.add("negate")
+        }
+        if (effectSettings.flipHorizontal) {
+            filters.add("hflip")
+        }
+        if (effectSettings.flipVertical) {
+            filters.add("vflip")
+        }
+        buildTextOverlayFilter(effectSettings.textOverlay)?.let(filters::add)
+        filters.add("format=rgba")
+        return filters
+    }
+
+    private fun buildTrimFilter(effectSettings: EffectSettings): String? {
+        val startMs = effectSettings.clipTrim.startMs
+        val endMs = effectSettings.clipTrim.endMs
+        if (startMs <= 0 && endMs == null) {
+            return null
+        }
+        val parts = mutableListOf<String>()
+        if (startMs > 0) {
+            parts += "start=${formatSeconds(startMs)}"
+        }
+        if (endMs != null) {
+            parts += "end=${formatSeconds(endMs)}"
+        }
+        return "trim=${parts.joinToString(":")}"
+    }
+
+    private fun buildEqFilter(effectSettings: EffectSettings): String {
+        return "eq=brightness=${formatDecimal(effectSettings.brightness.toDouble())}:" +
+            "contrast=${formatDecimal(effectSettings.contrast.toDouble())}:" +
+            "saturation=${formatDecimal(effectSettings.saturation.toDouble())}"
+    }
+
+    private fun buildColorBalanceFilter(balance: RgbBalance): String? {
+        if (isApproximately(balance.red, 1f) &&
+            isApproximately(balance.green, 1f) &&
+            isApproximately(balance.blue, 1f)
+        ) {
+            return null
+        }
+        return buildString {
+            append("colorchannelmixer=")
+            append("rr=${formatDecimal(balance.red.toDouble())}:")
+            append("rg=0:rb=0:")
+            append("gr=0:gg=${formatDecimal(balance.green.toDouble())}:")
+            append("gb=0:")
+            append("br=0:bg=0:bb=${formatDecimal(balance.blue.toDouble())}")
+        }
+    }
+
+    private fun buildHueFilter(hue: Float): String? {
+        if (isApproximatelyZero(hue)) {
+            return null
+        }
+        return "hue=h=${formatDecimal(hue.toDouble())}"
+    }
+
+    private fun buildTextOverlayFilter(overlay: TextOverlay): String? {
+        if (!overlay.enabled) {
+            return null
+        }
+        val sanitizedText = sanitizeOverlayText(overlay.text) ?: return null
+        val color = formatColor(overlay.colorArgb)
+        return "drawtext=text='$sanitizedText':fontsize=${overlay.fontSizeSp}:fontcolor=$color:" +
+            "x=(w-text_w)/2:y=(h-text_h)-10:borderw=2:bordercolor=0x000000AA"
+    }
+
+    private fun buildScaleFilter(resolutionPercent: Int): String {
+        val percent = resolutionPercent.coerceAtLeast(1)
+        return "scale=trunc(iw*${percent}/100/2)*2:trunc(ih*${percent}/100/2)*2:flags=lanczos"
+    }
+
+    private fun buildPaletteFilter(effectSettings: EffectSettings): String {
+        return "palettegen=max_colors=${effectSettings.maxColors}:stats_mode=diff"
+    }
+
+    private fun buildPaletteUseFilter(): String {
+        return "paletteuse=new=1:dither=bayer:bayer_scale=5"
+    }
+
+    private fun sanitizeOverlayText(text: String): String? {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) {
+            return null
+        }
+        return trimmed
+            .replace("\\", "\\\\")
+            .replace(":", "\\\\:")
+            .replace("'", "\\\\'")
+            .replace("\"", "\\\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "")
+    }
+
+    private fun formatColor(color: Int): String {
+        val unsigned = color.toLong() and 0xFFFFFFFFL
+        return String.format(Locale.US, "0x%08X", unsigned)
+    }
+
+    private fun formatDecimal(value: Double): String {
+        return String.format(Locale.US, "%.2f", value)
+    }
+
+    private fun formatSeconds(millis: Long): String {
+        return String.format(Locale.US, "%.3f", millis / 1000.0)
+    }
+
+    private fun isApproximately(value: Float, expected: Float): Boolean {
+        return abs(value - expected) < 0.0001f
+    }
+
+    private fun isApproximatelyZero(value: Float): Boolean = isApproximately(value, 0f)
+
+    companion object {
+        private const val SEPIA_FILTER = "colorchannelmixer=.393:.769:.189:.349:.686:.168:.272:.534:.131"
+    }
+}

--- a/core/ffmpeg/src/test/kotlin/com/example/gifvision/ffmpeg/FilterGraphBuilderTest.kt
+++ b/core/ffmpeg/src/test/kotlin/com/example/gifvision/ffmpeg/FilterGraphBuilderTest.kt
@@ -1,0 +1,114 @@
+package com.example.gifvision.ffmpeg
+
+import com.example.gifvision.ClipTrim
+import com.example.gifvision.EffectSettings
+import com.example.gifvision.GifTranscodeBlueprint
+import com.example.gifvision.RgbBalance
+import com.example.gifvision.TextOverlay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FilterGraphBuilderTest {
+
+    private val builder = FilterGraphBuilder()
+
+    @Test
+    fun `orders filters to match expected pipeline`() {
+        val baseBlueprint = GifTranscodeBlueprint.sampleBlueprint()
+        val overlay = TextOverlay(
+            text = "  Hello \"World\" : 'Test'  ",
+            fontSizeSp = 24,
+            colorArgb = 0x11223344.toInt(),
+            enabled = true
+        )
+        val customized = baseBlueprint.effectSettings.copy(
+            resolutionPercent = 50,
+            maxColors = 128,
+            frameRate = 24.0,
+            clipTrim = ClipTrim(startMs = 1_000, endMs = 3_500),
+            textOverlay = overlay,
+            brightness = 0.25f,
+            contrast = 1.5f,
+            saturation = 1.2f,
+            hue = 15f,
+            sepia = true,
+            rgbBalance = RgbBalance(red = 1.2f, green = 0.9f, blue = 1.1f),
+            chromaWarp = true,
+            colorCycleSpeed = 0.5f,
+            motionTrails = true,
+            sharpen = true,
+            edgeDetect = true,
+            negate = true,
+            flipHorizontal = true,
+            flipVertical = true
+        )
+        val graphs = builder.buildStreamGraphs(baseBlueprint.copy(effectSettings = customized), customized)
+
+        val expectedFilters = listOf(
+            "trim=start=1.000:end=3.500",
+            "setpts=PTS-STARTPTS",
+            "fps=24.00",
+            "scale=trunc(iw*50/100/2)*2:trunc(ih*50/100/2)*2:flags=lanczos",
+            "eq=brightness=0.25:contrast=1.50:saturation=1.20",
+            "colorchannelmixer=rr=1.20:rg=0:rb=0:gr=0:gg=0.90:gb=0:br=0:bg=0:bb=1.10",
+            "hue=h=15.00",
+            "colorchannelmixer=.393:.769:.189:.349:.686:.168:.272:.534:.131",
+            "chromashift=cb=5:cr=-5",
+            "hue='H+0.50*t'",
+            "tmix=frames=3:weights='1 1 1'",
+            "unsharp=5:5:1.0:5:5:0.0",
+            "edgedetect=mode=colormix:high=0.2:low=0.1",
+            "negate",
+            "hflip",
+            "vflip",
+            "drawtext=text='Hello \\"World\\" \\:\\ \\'Test\\'':fontsize=24:fontcolor=0x11223344:x=(w-text_w)/2:y=(h-text_h)-10:borderw=2:bordercolor=0x000000AA",
+            "format=rgba"
+        )
+        assertEquals(expectedFilters, graphs.baseFilters)
+    }
+
+    @Test
+    fun `skips optional filters when disabled`() {
+        val blueprint = baseBlueprint()
+        val defaults = EffectSettings.defaultSettings(blueprint.streamId)
+        val graphs = builder.buildStreamGraphs(blueprint.copy(effectSettings = defaults), defaults)
+
+        assertFalse(graphs.baseFilters.any { it.contains("chromashift") })
+        assertFalse(graphs.baseFilters.any { it.contains("tmix") })
+        assertFalse(graphs.baseFilters.any { it.contains("unsharp") })
+        assertFalse(graphs.baseFilters.any { it.contains("edgedetect") })
+        assertFalse(graphs.baseFilters.any { it.contains("negate") })
+        assertFalse(graphs.baseFilters.any { it.contains("drawtext") })
+        assertTrue(graphs.baseFilters.contains("format=rgba"))
+    }
+
+    @Test
+    fun `palette chains append palette stages`() {
+        val blueprint = baseBlueprint()
+        val graphs = builder.buildStreamGraphs(blueprint, blueprint.effectSettings)
+
+        assertTrue(graphs.paletteFilters.last().startsWith("palettegen"))
+        assertTrue(graphs.renderFilters.last().startsWith("paletteuse"))
+        assertEquals(
+            graphs.baseFilters.size + 1,
+            graphs.paletteFilters.size
+        )
+        assertEquals(
+            graphs.baseFilters.size + 1,
+            graphs.renderFilters.size
+        )
+    }
+
+    @Test
+    fun `palette generation respects max colors`() {
+        val blueprint = baseBlueprint()
+        val customized = blueprint.effectSettings.copy(maxColors = 32)
+        val graphs = builder.buildStreamGraphs(blueprint.copy(effectSettings = customized), customized)
+
+        assertTrue(graphs.paletteFilters.last().contains("max_colors=32"))
+    }
+
+    private fun baseBlueprint(): GifTranscodeBlueprint = GifTranscodeBlueprint.sampleBlueprint()
+}


### PR DESCRIPTION
## Summary
- add a reusable FfmpegKitCommandRunner that routes FFmpegKit async output into structured callbacks for workers
- implement FilterGraphBuilder to assemble stream render, palette, and blend filter graphs with text sanitization and optional effect handling
- introduce regression tests covering filter ordering, toggle behavior, and palette parameters while wiring in unit-test dependencies

## Testing
- `./gradlew :core:ffmpeg:testDebugUnitTest` *(fails: Android SDK is not available in the execution environment)*
- `./gradlew :core:ffmpeg:compileDebugUnitTestKotlin` *(fails: required Java 11 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e07e1bd7a88320a6340eeecf1b2ca5