### PR TITLE
Implement FFmpeg workers for GIF rendering and blending

### DIFF
--- a/core/ffmpeg/src/main/AndroidManifest.xml
+++ b/core/ffmpeg/src/main/AndroidManifest.xml
@@ -1,2 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.giffer2.core.ffmpeg" />
+<manifest package="com.example.giffer2.core.ffmpeg"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <meta-data
+            android:name="com.example.gifvision.ffmpeg.GifGenerationWorker"
+            android:value="worker" />
+        <meta-data
+            android:name="com.example.gifvision.ffmpeg.GifBlendWorker"
+            android:value="worker" />
+        <meta-data
+            android:name="com.example.gifvision.ffmpeg.MasterBlendWorker"
+            android:value="worker" />
+    </application>
+
+</manifest>

--- a/core/ffmpeg/src/main/java/com/example/giffer2/core/ffmpeg/FfmpegKitInitializer.kt
+++ b/core/ffmpeg/src/main/java/com/example/giffer2/core/ffmpeg/FfmpegKitInitializer.kt
@@ -35,4 +35,15 @@ object FfmpegKitInitializer {
             }
         }
     }
+
+    /**
+     * Ensures the FFmpegKit toolchain is initialized before a background worker executes. The
+     * method is safe to call for every WorkManager invocation; initialization only runs once per
+     * process.
+     */
+    fun ensureInitialized(context: Context) {
+        if (!initialized.get()) {
+            initialize(context)
+        }
+    }
 }

--- a/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/BaseBlendWorker.kt
+++ b/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/BaseBlendWorker.kt
@@ -1,0 +1,333 @@
+package com.example.gifvision.ffmpeg
+
+import android.content.Context
+import android.net.Uri
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.FFmpegSession
+import com.arthenica.ffmpegkit.ReturnCode
+import com.example.gifvision.BlendMode
+import com.example.gifvision.GifWorkDataKeys
+import com.example.gifvision.LogEntry
+import com.example.gifvision.LogSeverity
+import com.example.gifvision.toJsonArray
+import com.example.giffer2.core.ffmpeg.FfmpegKitInitializer
+import java.io.File
+import java.io.FileOutputStream
+import java.util.ArrayDeque
+import java.util.Locale
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Shared execution harness for blend workers. Subclasses only implement request parsing and
+ * success payload assembly while this base class handles resolution, padding, FFmpeg invocation,
+ * and standardized logging/failure data.
+ */
+abstract class BaseBlendWorker<I : BaseBlendWorker.BlendInputs>(
+    appContext: Context,
+    workerParameters: WorkerParameters
+) : CoroutineWorker(appContext, workerParameters) {
+
+    protected interface BlendInputs {
+        val primaryUri: String
+        val secondaryUri: String
+        val blendMode: BlendMode
+        val blendOpacity: Float
+        val label: String
+    }
+
+    private val commandRunner = FfmpegKitCommandRunner()
+    private val filterGraphBuilder = FilterGraphBuilder()
+
+    final override suspend fun doWork(): Result {
+        FfmpegKitInitializer.ensureInitialized(applicationContext)
+
+        val logs = mutableListOf<LogEntry>()
+        val inputs = parseInputs(inputData)
+        if (inputs == null) {
+            logs += LogEntry(
+                message = "Blend worker received invalid input payload",
+                severity = LogSeverity.ERROR,
+                workId = id
+            )
+            return onBlendFailure(
+                inputs = null,
+                reason = GifWorkDataKeys.FAILURE_REASON_INVALID_INPUT,
+                detail = "missing_inputs",
+                exitCode = null,
+                stderrTail = emptyList(),
+                logs = logs
+            )
+        }
+
+        val primary = runCatching { resolveInput(inputs.primaryUri, "primary_${inputs.label}") }
+            .getOrElse { error ->
+                logs += LogEntry(
+                    message = "Unable to resolve primary input: ${error.message}",
+                    severity = LogSeverity.ERROR,
+                    workId = id
+                )
+                return onBlendFailure(
+                    inputs = inputs,
+                    reason = GifWorkDataKeys.FAILURE_REASON_INVALID_INPUT,
+                    detail = "primary_unavailable",
+                    exitCode = null,
+                    stderrTail = emptyList(),
+                    logs = logs
+                )
+            }
+
+        val secondary = runCatching { resolveInput(inputs.secondaryUri, "secondary_${inputs.label}") }
+            .getOrElse { error ->
+                logs += LogEntry(
+                    message = "Unable to resolve secondary input: ${error.message}",
+                    severity = LogSeverity.ERROR,
+                    workId = id
+                )
+                cleanup(primary)
+                return onBlendFailure(
+                    inputs = inputs,
+                    reason = GifWorkDataKeys.FAILURE_REASON_INVALID_INPUT,
+                    detail = "secondary_unavailable",
+                    exitCode = null,
+                    stderrTail = emptyList(),
+                    logs = logs
+                )
+            }
+
+        val outputFile = createOutputFile(inputs)
+
+        return try {
+            val filterComplex = buildBlendFilter(inputs)
+            val command = buildBlendCommand(primary.file, secondary.file, outputFile, filterComplex)
+            val result = executeCommand(command, logs)
+            if (result.isSuccess) {
+                onBlendSuccess(inputs, outputFile, result.exitCode, result.stderrTail, logs)
+            } else {
+                logs += LogEntry(
+                    message = "Blend command failed with exit code ${result.exitCode ?: -1}",
+                    severity = LogSeverity.ERROR,
+                    workId = id
+                )
+                onBlendFailure(
+                    inputs = inputs,
+                    reason = GifWorkDataKeys.FAILURE_REASON_FFMPEG_ERROR,
+                    detail = "blend_failed",
+                    exitCode = result.exitCode,
+                    stderrTail = result.stderrTail,
+                    logs = logs
+                )
+            }
+        } catch (throwable: Throwable) {
+            logs += LogEntry(
+                message = "Blend worker crashed: ${throwable.message ?: throwable::class.java.simpleName}",
+                severity = LogSeverity.ERROR,
+                workId = id
+            )
+            onBlendFailure(
+                inputs = inputs,
+                reason = GifWorkDataKeys.FAILURE_REASON_EXCEPTION,
+                detail = throwable.message,
+                exitCode = null,
+                stderrTail = emptyList(),
+                logs = logs
+            )
+        } finally {
+            cleanup(primary)
+            cleanup(secondary)
+        }
+    }
+
+    protected abstract fun parseInputs(data: Data): I?
+
+    protected open fun createOutputFile(inputs: I): File {
+        return File.createTempFile("blend_${inputs.label}", ".gif", applicationContext.cacheDir)
+    }
+
+    protected open fun buildBlendFilter(inputs: I): String {
+        val baseFilter = buildNormalizedScalePadFilter()
+        val blendGraph = filterGraphBuilder.buildBlendGraph(inputs.blendMode, inputs.blendOpacity)
+            .replace("[0:v]", "[base]")
+            .replace("[1:v]", "[overlay]")
+        return buildString {
+            append("[0:v]")
+            append(baseFilter)
+            append("[base];")
+            append("[1:v]")
+            append(baseFilter)
+            append("[overlay];")
+            append(blendGraph)
+        }
+    }
+
+    protected abstract fun onBlendSuccess(
+        inputs: I,
+        outputFile: File,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result
+
+    protected open fun onBlendFailure(
+        inputs: I?,
+        reason: String,
+        detail: String?,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_FAILURE_REASON, reason)
+        detail?.let { data.putString(GifWorkDataKeys.KEY_FAILURE_DETAIL, it) }
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        inputs?.let {
+            data.putString(GifWorkDataKeys.KEY_INPUT_PRIMARY_URI, it.primaryUri)
+            data.putString(GifWorkDataKeys.KEY_INPUT_SECONDARY_URI, it.secondaryUri)
+        }
+        return Result.failure(data.build())
+    }
+
+    private suspend fun executeCommand(
+        command: String,
+        logs: MutableList<LogEntry>
+    ): CommandResult = suspendCancellableCoroutine { continuation ->
+        val stderrTail = ArrayDeque<String>()
+        var sessionRef: FFmpegSession? = null
+        val callbacks = FfmpegKitCommandRunner.Callbacks(
+            onStdout = { line ->
+                if (line.isNotBlank()) {
+                    logs += LogEntry(line, LogSeverity.INFO, workId = id)
+                }
+            },
+            onStderr = { line ->
+                if (line.isNotBlank()) {
+                    val severity = if (line.contains("warn", ignoreCase = true)) {
+                        LogSeverity.WARNING
+                    } else {
+                        LogSeverity.ERROR
+                    }
+                    logs += LogEntry(line, severity, workId = id)
+                    if (stderrTail.size >= STDERR_TAIL_LIMIT) {
+                        stderrTail.removeFirst()
+                    }
+                    stderrTail.addLast(line)
+                }
+            },
+            onComplete = { session ->
+                sessionRef = session
+                if (continuation.isActive) {
+                    continuation.resume(CommandResult(session, stderrTail.toList()))
+                }
+            }
+        )
+        sessionRef = commandRunner.execute(command, callbacks)
+        continuation.invokeOnCancellation {
+            sessionRef?.let { FFmpegKit.cancel(it.sessionId) }
+        }
+    }
+
+    private fun buildBlendCommand(
+        primary: File,
+        secondary: File,
+        output: File,
+        filterComplex: String
+    ): String {
+        val args = listOf(
+            "-y",
+            "-i",
+            primary.absolutePath,
+            "-i",
+            secondary.absolutePath,
+            "-filter_complex",
+            filterComplex,
+            "-loop",
+            "0",
+            "-gifflags",
+            "+transdiff",
+            output.absolutePath
+        )
+        return joinArguments(args)
+    }
+
+    private fun resolveInput(rawUri: String, label: String): ResolvedInput {
+        val uri = Uri.parse(rawUri)
+        return when (uri.scheme) {
+            null, "file" -> {
+                val file = File(uri.path ?: rawUri)
+                require(file.exists()) { "Input file does not exist: ${file.absolutePath}" }
+                ResolvedInput(file, deleteOnCleanup = false)
+            }
+
+            "content" -> copyUriToCache(uri, label)
+
+            else -> {
+                val file = File(uri.path ?: rawUri)
+                if (file.exists()) {
+                    ResolvedInput(file, deleteOnCleanup = false)
+                } else {
+                    copyUriToCache(uri, label)
+                }
+            }
+        }
+    }
+
+    private fun copyUriToCache(uri: Uri, label: String): ResolvedInput {
+        val suffix = uri.lastPathSegment?.substringAfterLast('.', missingDelimiterValue = "")?.takeIf { it.isNotEmpty() }
+            ?.let { ".${it}" } ?: ".gif"
+        val temp = File.createTempFile(label.lowercase(Locale.US), suffix, applicationContext.cacheDir)
+        val resolver = applicationContext.contentResolver
+        resolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(temp).use { output ->
+                input.copyTo(output)
+            }
+        } ?: error("Unable to open URI: $uri")
+        return ResolvedInput(temp, deleteOnCleanup = true)
+    }
+
+    private fun cleanup(resolved: ResolvedInput?) {
+        if (resolved?.deleteOnCleanup == true) {
+            resolved.file.delete()
+        }
+    }
+
+    private fun joinArguments(arguments: List<String>): String {
+        return arguments.joinToString(" ") { argument ->
+            if (argument.isBlank()) {
+                "\"\""
+            } else if (argument.any { it.isWhitespace() }) {
+                "\"${argument.replace("\"", "\\\"")}\""
+            } else {
+                argument
+            }
+        }.trim()
+    }
+
+    private fun buildNormalizedScalePadFilter(): String {
+        return "scale=$TARGET_WIDTH:$TARGET_HEIGHT:force_original_aspect_ratio=decrease," +
+            "pad=$TARGET_WIDTH:$TARGET_HEIGHT:(ow-iw)/2:(oh-ih)/2:black,format=rgba"
+    }
+
+    private data class ResolvedInput(val file: File, val deleteOnCleanup: Boolean)
+
+    private data class CommandResult(val session: FFmpegSession, val stderrTail: List<String>) {
+        val exitCode: Int?
+            get() = session.returnCode?.value
+        val isSuccess: Boolean
+            get() = ReturnCode.isSuccess(session.returnCode)
+    }
+
+    companion object {
+        private const val TARGET_WIDTH = 1280
+        private const val TARGET_HEIGHT = 720
+        private const val STDERR_TAIL_LIMIT = 20
+    }
+}

--- a/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/GifBlendWorker.kt
+++ b/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/GifBlendWorker.kt
@@ -1,0 +1,100 @@
+package com.example.gifvision.ffmpeg
+
+import android.content.Context
+import android.net.Uri
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import com.example.gifvision.BlendMode
+import com.example.gifvision.GifWorkDataKeys
+import com.example.gifvision.LogEntry
+import com.example.gifvision.StreamId
+import com.example.gifvision.toJsonArray
+import java.io.File
+import java.util.Locale
+
+/**
+ * Blends Stream A and Stream B outputs for a single layer, returning the resulting GIF URI.
+ */
+class GifBlendWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters
+) : BaseBlendWorker<GifBlendWorker.LayerBlendInputs>(appContext, workerParameters) {
+
+    data class LayerBlendInputs(
+        override val primaryUri: String,
+        override val secondaryUri: String,
+        override val blendMode: BlendMode,
+        override val blendOpacity: Float,
+        val streamId: StreamId
+    ) : BlendInputs {
+        override val label: String =
+            "${streamId.layer.displayName}_${streamId.channel.displayName}".replace(" ", "_").lowercase(Locale.US)
+    }
+
+    override fun parseInputs(data: Data): LayerBlendInputs? {
+        val primary = data.getString(GifWorkDataKeys.KEY_INPUT_PRIMARY_URI) ?: return null
+        val secondary = data.getString(GifWorkDataKeys.KEY_INPUT_SECONDARY_URI) ?: return null
+        val blendModeToken = data.getString(GifWorkDataKeys.KEY_INPUT_BLEND_MODE) ?: return null
+        val blendMode = runCatching { BlendMode.valueOf(blendModeToken) }.getOrNull() ?: return null
+        val opacity = data.getFloat(GifWorkDataKeys.KEY_INPUT_BLEND_OPACITY, Float.NaN)
+        if (opacity.isNaN()) {
+            return null
+        }
+        val streamValue = data.getInt(GifWorkDataKeys.KEY_INPUT_STREAM_ID, Int.MIN_VALUE)
+        if (streamValue == Int.MIN_VALUE) {
+            return null
+        }
+        val streamId = runCatching { StreamId.fromWorkValue(streamValue) }.getOrNull() ?: return null
+        return LayerBlendInputs(primary, secondary, blendMode, opacity, streamId)
+    }
+
+    override fun onBlendSuccess(
+        inputs: LayerBlendInputs,
+        outputFile: File,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_OUTPUT_GIF_URI, Uri.fromFile(outputFile).toString())
+            .putInt(GifWorkDataKeys.KEY_INPUT_STREAM_ID, inputs.streamId.toWorkValue())
+            .putString(GifWorkDataKeys.KEY_INPUT_BLEND_MODE, inputs.blendMode.name)
+            .putFloat(GifWorkDataKeys.KEY_INPUT_BLEND_OPACITY, inputs.blendOpacity)
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        return Result.success(data.build())
+    }
+
+    override fun onBlendFailure(
+        inputs: LayerBlendInputs?,
+        reason: String,
+        detail: String?,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_FAILURE_REASON, reason)
+        detail?.let { data.putString(GifWorkDataKeys.KEY_FAILURE_DETAIL, it) }
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        inputs?.let {
+            data.putInt(GifWorkDataKeys.KEY_INPUT_STREAM_ID, it.streamId.toWorkValue())
+            data.putString(GifWorkDataKeys.KEY_INPUT_PRIMARY_URI, it.primaryUri)
+            data.putString(GifWorkDataKeys.KEY_INPUT_SECONDARY_URI, it.secondaryUri)
+            data.putString(GifWorkDataKeys.KEY_INPUT_BLEND_MODE, it.blendMode.name)
+            data.putFloat(GifWorkDataKeys.KEY_INPUT_BLEND_OPACITY, it.blendOpacity)
+        }
+        return Result.failure(data.build())
+    }
+}

--- a/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/GifGenerationWorker.kt
+++ b/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/GifGenerationWorker.kt
@@ -1,0 +1,330 @@
+package com.example.gifvision.ffmpeg
+
+import android.content.Context
+import android.net.Uri
+import androidx.work.Data
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.FFmpegSession
+import com.arthenica.ffmpegkit.ReturnCode
+import com.example.gifvision.GifTranscodeBlueprint
+import com.example.gifvision.GifReference
+import com.example.gifvision.GifWorkDataKeys
+import com.example.gifvision.LogEntry
+import com.example.gifvision.LogSeverity
+import com.example.gifvision.toJsonArray
+import com.example.giffer2.core.ffmpeg.FfmpegKitInitializer
+import java.io.File
+import java.io.FileOutputStream
+import java.util.ArrayDeque
+import java.util.Locale
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Executes the two-pass GIF pipeline (palette generation + GIF render) for a single stream.
+ * The worker normalizes FFmpeg stdout/stderr into [LogEntry] payloads so the UI can render
+ * diagnostics inline with progress updates.
+ */
+class GifGenerationWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters
+) : CoroutineWorker(appContext, workerParameters) {
+
+    private val commandRunner = FfmpegKitCommandRunner()
+    private val filterGraphBuilder = FilterGraphBuilder()
+
+    override suspend fun doWork(): Result {
+        FfmpegKitInitializer.ensureInitialized(applicationContext)
+
+        val logs = mutableListOf<LogEntry>()
+        val blueprint = runCatching { GifTranscodeBlueprint.fromWorkData(inputData) }
+            .getOrElse { error ->
+                logs += LogEntry(
+                    message = "Failed to parse blueprint: ${error.message}",
+                    severity = LogSeverity.ERROR,
+                    workId = id
+                )
+                return failureResult(
+                    reason = GifWorkDataKeys.FAILURE_REASON_INVALID_INPUT,
+                    detail = error.message,
+                    exitCode = null,
+                    stderrTail = emptyList(),
+                    logs = logs
+                )
+            }
+
+        var resolvedSource: ResolvedSource? = null
+        var paletteFile: File? = null
+        var outputFile: File? = null
+
+        return try {
+            resolvedSource = resolveSource(blueprint)
+            val graphs = filterGraphBuilder.buildStreamGraphs(blueprint)
+            paletteFile = File.createTempFile(
+                "palette_${blueprint.streamId.layer.index}_${blueprint.streamId.channel.name.lowercase(Locale.US)}",
+                ".png",
+                applicationContext.cacheDir
+            )
+            outputFile = File.createTempFile(
+                "gif_${blueprint.streamId.layer.index}_${blueprint.streamId.channel.name.lowercase(Locale.US)}",
+                ".gif",
+                applicationContext.cacheDir
+            )
+
+            val paletteResult = executeCommand(
+                command = buildPaletteCommand(resolvedSource.file, paletteFile, graphs),
+                stderrTail = ArrayDeque(),
+                logs = logs
+            )
+            if (!paletteResult.isSuccess) {
+                logs += LogEntry(
+                    message = "Palette generation failed with exit code ${paletteResult.exitCode ?: -1}",
+                    severity = LogSeverity.ERROR,
+                    workId = id
+                )
+                return failureResult(
+                    reason = GifWorkDataKeys.FAILURE_REASON_FFMPEG_ERROR,
+                    detail = "palette_generation_failed",
+                    exitCode = paletteResult.exitCode,
+                    stderrTail = paletteResult.stderrTail,
+                    logs = logs
+                )
+            }
+
+            val renderResult = executeCommand(
+                command = buildRenderCommand(resolvedSource.file, paletteFile, outputFile, graphs),
+                stderrTail = ArrayDeque(),
+                logs = logs
+            )
+            if (!renderResult.isSuccess) {
+                logs += LogEntry(
+                    message = "GIF rendering failed with exit code ${renderResult.exitCode ?: -1}",
+                    severity = LogSeverity.ERROR,
+                    workId = id
+                )
+                return failureResult(
+                    reason = GifWorkDataKeys.FAILURE_REASON_FFMPEG_ERROR,
+                    detail = "gif_render_failed",
+                    exitCode = renderResult.exitCode,
+                    stderrTail = renderResult.stderrTail,
+                    logs = logs
+                )
+            }
+
+            successResult(outputFile, renderResult.exitCode, renderResult.stderrTail, logs)
+        } catch (throwable: Throwable) {
+            logs += LogEntry(
+                message = "GifGenerationWorker failed: ${throwable.message ?: throwable::class.java.simpleName}",
+                severity = LogSeverity.ERROR,
+                workId = id
+            )
+            failureResult(
+                reason = GifWorkDataKeys.FAILURE_REASON_EXCEPTION,
+                detail = throwable.message,
+                exitCode = null,
+                stderrTail = emptyList(),
+                logs = logs
+            )
+        } finally {
+            paletteFile?.delete()
+            if (resolvedSource?.deleteOnCleanup == true) {
+                resolvedSource.file.delete()
+            }
+        }
+    }
+
+    private fun successResult(
+        outputFile: File,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_OUTPUT_GIF_URI, Uri.fromFile(outputFile).toString())
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        return Result.success(data.build())
+    }
+
+    private fun failureResult(
+        reason: String,
+        detail: String?,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_FAILURE_REASON, reason)
+        detail?.let { data.putString(GifWorkDataKeys.KEY_FAILURE_DETAIL, it) }
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        return Result.failure(data.build())
+    }
+
+    private fun buildPaletteCommand(
+        inputFile: File,
+        paletteFile: File,
+        graphs: FilterGraphBuilder.StreamGraphs
+    ): String {
+        val args = listOf(
+            "-y",
+            "-i",
+            inputFile.absolutePath,
+            "-vf",
+            graphs.paletteGraph,
+            "-frames:v",
+            "1",
+            paletteFile.absolutePath
+        )
+        return joinArguments(args)
+    }
+
+    private fun buildRenderCommand(
+        inputFile: File,
+        paletteFile: File,
+        outputFile: File,
+        graphs: FilterGraphBuilder.StreamGraphs
+    ): String {
+        val renderFilters = graphs.renderFilters
+        require(renderFilters.isNotEmpty()) { "Render filter chain cannot be empty" }
+        val baseFilters = renderFilters.dropLast(1).joinToString(",")
+        val paletteUse = renderFilters.last()
+        val filterComplex = if (baseFilters.isEmpty()) {
+            "[0:v][1:v]$paletteUse"
+        } else {
+            "[0:v]$baseFilters[base];[base][1:v]$paletteUse"
+        }
+        val args = listOf(
+            "-y",
+            "-i",
+            inputFile.absolutePath,
+            "-i",
+            paletteFile.absolutePath,
+            "-filter_complex",
+            filterComplex,
+            "-loop",
+            "0",
+            "-gifflags",
+            "+transdiff",
+            outputFile.absolutePath
+        )
+        return joinArguments(args)
+    }
+
+    private suspend fun executeCommand(
+        command: String,
+        stderrTail: ArrayDeque<String>,
+        logs: MutableList<LogEntry>
+    ): CommandResult = suspendCancellableCoroutine { continuation ->
+        stderrTail.clear()
+        var sessionRef: FFmpegSession? = null
+        val callbacks = FfmpegKitCommandRunner.Callbacks(
+            onStdout = { line ->
+                if (line.isNotBlank()) {
+                    logs += LogEntry(line, LogSeverity.INFO, workId = id)
+                }
+            },
+            onStderr = { line ->
+                if (line.isNotBlank()) {
+                    val severity = if (line.contains("warn", ignoreCase = true)) {
+                        LogSeverity.WARNING
+                    } else {
+                        LogSeverity.ERROR
+                    }
+                    logs += LogEntry(line, severity, workId = id)
+                    if (stderrTail.size >= STDERR_TAIL_LIMIT) {
+                        stderrTail.removeFirst()
+                    }
+                    stderrTail.addLast(line)
+                }
+            },
+            onComplete = { session ->
+                sessionRef = session
+                if (continuation.isActive) {
+                    continuation.resume(CommandResult(session, stderrTail.toList()))
+                }
+            }
+        )
+        sessionRef = commandRunner.execute(command, callbacks)
+        continuation.invokeOnCancellation {
+            sessionRef?.let { FFmpegKit.cancel(it.sessionId) }
+        }
+    }
+
+    private fun resolveSource(blueprint: GifTranscodeBlueprint): ResolvedSource {
+        val source = blueprint.source
+        val label = "${blueprint.streamId.layer.displayName}_${blueprint.streamId.channel.displayName}".replace(" ", "_")
+        return when (source) {
+            is GifReference.FileUri -> {
+                val uri = Uri.parse(source.uri)
+                if (uri.scheme == null || uri.scheme == "file") {
+                    val file = File(uri.path ?: source.uri)
+                    require(file.exists()) { "Input file does not exist: ${file.absolutePath}" }
+                    ResolvedSource(file, deleteOnCleanup = false)
+                } else {
+                    copyUriToCache(uri, label)
+                }
+            }
+
+            is GifReference.ContentUri -> copyUriToCache(Uri.parse(source.uri), label)
+
+            is GifReference.InMemory -> {
+                val temp = File.createTempFile("source_${label}", ".gif", applicationContext.cacheDir)
+                FileOutputStream(temp).use { output ->
+                    output.write(source.bytes)
+                }
+                ResolvedSource(temp, deleteOnCleanup = true)
+            }
+        }
+    }
+
+    private fun copyUriToCache(uri: Uri, label: String): ResolvedSource {
+        val suffix = uri.lastPathSegment?.substringAfterLast('.', missingDelimiterValue = "")?.takeIf { it.isNotEmpty() }
+            ?.let { ".${it}" } ?: ".gif"
+        val temp = File.createTempFile("import_${label}", suffix, applicationContext.cacheDir)
+        val resolver = applicationContext.contentResolver
+        resolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(temp).use { output ->
+                input.copyTo(output)
+            }
+        } ?: error("Unable to open content URI: $uri")
+        return ResolvedSource(temp, deleteOnCleanup = true)
+    }
+
+    private fun joinArguments(arguments: List<String>): String {
+        return arguments.joinToString(" ") { argument ->
+            if (argument.isBlank()) {
+                "\"\""
+            } else if (argument.any { it.isWhitespace() }) {
+                "\"${argument.replace("\"", "\\\"")}\""
+            } else {
+                argument
+            }
+        }.trim()
+    }
+
+    private data class ResolvedSource(val file: File, val deleteOnCleanup: Boolean)
+
+    private data class CommandResult(val session: FFmpegSession, val stderrTail: List<String>) {
+        val exitCode: Int?
+            get() = session.returnCode?.value
+        val isSuccess: Boolean
+            get() = ReturnCode.isSuccess(session.returnCode)
+    }
+
+    companion object {
+        private const val STDERR_TAIL_LIMIT = 20
+    }
+}

--- a/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/MasterBlendWorker.kt
+++ b/core/ffmpeg/src/main/kotlin/com/example/gifvision/ffmpeg/MasterBlendWorker.kt
@@ -1,0 +1,94 @@
+package com.example.gifvision.ffmpeg
+
+import android.content.Context
+import android.net.Uri
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import com.example.gifvision.BlendMode
+import com.example.gifvision.GifWorkDataKeys
+import com.example.gifvision.LogEntry
+import com.example.gifvision.toJsonArray
+import java.io.File
+import java.util.Locale
+
+/**
+ * Combines the blended outputs from Layer 1 and Layer 2 into a master GIF composite.
+ */
+class MasterBlendWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters
+) : BaseBlendWorker<MasterBlendWorker.MasterBlendInputs>(appContext, workerParameters) {
+
+    data class MasterBlendInputs(
+        override val primaryUri: String,
+        override val secondaryUri: String,
+        override val blendMode: BlendMode,
+        override val blendOpacity: Float,
+        val masterLabel: String
+    ) : BlendInputs {
+        override val label: String = masterLabel.replace(" ", "_").lowercase(Locale.US)
+    }
+
+    override fun parseInputs(data: Data): MasterBlendInputs? {
+        val primary = data.getString(GifWorkDataKeys.KEY_INPUT_PRIMARY_URI) ?: return null
+        val secondary = data.getString(GifWorkDataKeys.KEY_INPUT_SECONDARY_URI) ?: return null
+        val blendModeToken = data.getString(GifWorkDataKeys.KEY_INPUT_BLEND_MODE) ?: return null
+        val blendMode = runCatching { BlendMode.valueOf(blendModeToken) }.getOrNull() ?: return null
+        val opacity = data.getFloat(GifWorkDataKeys.KEY_INPUT_BLEND_OPACITY, Float.NaN)
+        if (opacity.isNaN()) {
+            return null
+        }
+        val label = data.getString(GifWorkDataKeys.KEY_INPUT_MASTER_LABEL) ?: "master"
+        return MasterBlendInputs(primary, secondary, blendMode, opacity, label)
+    }
+
+    override fun onBlendSuccess(
+        inputs: MasterBlendInputs,
+        outputFile: File,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_OUTPUT_GIF_URI, Uri.fromFile(outputFile).toString())
+            .putString(GifWorkDataKeys.KEY_INPUT_MASTER_LABEL, inputs.masterLabel)
+            .putString(GifWorkDataKeys.KEY_INPUT_BLEND_MODE, inputs.blendMode.name)
+            .putFloat(GifWorkDataKeys.KEY_INPUT_BLEND_OPACITY, inputs.blendOpacity)
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        return Result.success(data.build())
+    }
+
+    override fun onBlendFailure(
+        inputs: MasterBlendInputs?,
+        reason: String,
+        detail: String?,
+        exitCode: Int?,
+        stderrTail: List<String>,
+        logs: List<LogEntry>
+    ): Result {
+        val data = Data.Builder()
+            .putString(GifWorkDataKeys.KEY_FAILURE_REASON, reason)
+        detail?.let { data.putString(GifWorkDataKeys.KEY_FAILURE_DETAIL, it) }
+        exitCode?.let { data.putInt(GifWorkDataKeys.KEY_OUTPUT_EXIT_CODE, it) }
+        if (stderrTail.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_STDERR_TAIL, stderrTail.toTypedArray())
+        }
+        if (logs.isNotEmpty()) {
+            data.putStringArray(GifWorkDataKeys.KEY_OUTPUT_LOGS, logs.toJsonArray())
+        }
+        inputs?.let {
+            data.putString(GifWorkDataKeys.KEY_INPUT_MASTER_LABEL, it.masterLabel)
+            data.putString(GifWorkDataKeys.KEY_INPUT_PRIMARY_URI, it.primaryUri)
+            data.putString(GifWorkDataKeys.KEY_INPUT_SECONDARY_URI, it.secondaryUri)
+            data.putString(GifWorkDataKeys.KEY_INPUT_BLEND_MODE, it.blendMode.name)
+            data.putFloat(GifWorkDataKeys.KEY_INPUT_BLEND_OPACITY, it.blendOpacity)
+        }
+        return Result.failure(data.build())
+    }
+}

--- a/core/model/src/main/kotlin/com/example/gifvision/GifWorkDataKeys.kt
+++ b/core/model/src/main/kotlin/com/example/gifvision/GifWorkDataKeys.kt
@@ -1,0 +1,32 @@
+package com.example.gifvision
+
+/**
+ * Central registry for WorkManager input/output keys shared by GifVision workers.
+ * Keeping the constants in one place ensures the UI and background layers stay in sync
+ * and avoids subtle typos when building Data payloads.
+ */
+object GifWorkDataKeys {
+    // Generic input keys
+    const val KEY_INPUT_PRIMARY_URI: String = "gifvision.input.primaryUri"
+    const val KEY_INPUT_SECONDARY_URI: String = "gifvision.input.secondaryUri"
+    const val KEY_INPUT_BLEND_MODE: String = "gifvision.input.blendMode"
+    const val KEY_INPUT_BLEND_OPACITY: String = "gifvision.input.blendOpacity"
+    const val KEY_INPUT_LAYER_INDEX: String = "gifvision.input.layerIndex"
+    const val KEY_INPUT_STREAM_ID: String = "gifvision.input.streamId"
+    const val KEY_INPUT_MASTER_LABEL: String = "gifvision.input.masterLabel"
+
+    // Generic output keys
+    const val KEY_OUTPUT_GIF_URI: String = "gifvision.output.gifUri"
+    const val KEY_OUTPUT_LOGS: String = "gifvision.output.logs"
+    const val KEY_OUTPUT_STDERR_TAIL: String = "gifvision.output.stderrTail"
+    const val KEY_OUTPUT_EXIT_CODE: String = "gifvision.output.exitCode"
+
+    // Failure specific keys
+    const val KEY_FAILURE_REASON: String = "gifvision.failure.reason"
+    const val KEY_FAILURE_DETAIL: String = "gifvision.failure.detail"
+
+    // Standardized failure reasons to keep analytics consistent.
+    const val FAILURE_REASON_INVALID_INPUT: String = "invalid_input"
+    const val FAILURE_REASON_FFMPEG_ERROR: String = "ffmpeg_error"
+    const val FAILURE_REASON_EXCEPTION: String = "uncaught_exception"
+}


### PR DESCRIPTION
## Summary
- add GifGenerationWorker that orchestrates the palette/GIF passes via FFmpegKit and records structured logs
- introduce BaseBlendWorker along with GifBlendWorker and MasterBlendWorker to standardize 1280×720 blend executions and outputs
- centralize WorkManager data keys, add log serialization helpers, and register the workers while exposing an initialization guard

## Testing
- ./gradlew test *(fails: Android SDK not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68e0803c2d3c8320b22facdb09c38725