### PR TITLE
Implement deterministic GIF exports with save and share flows

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="gif_exports" path="exports/" />
+    <files-path name="gif_sources" path="sources/" />
+</paths>

--- a/core/model/src/main/kotlin/com/example/gifvision/GifExportTarget.kt
+++ b/core/model/src/main/kotlin/com/example/gifvision/GifExportTarget.kt
@@ -1,0 +1,61 @@
+package com.example.gifvision
+
+import java.util.Locale
+
+/**
+ * Describes a GIF artifact that can be exported or shared with external apps.
+ *
+ * The target centralizes deterministic naming so callers can use the same
+ * vocabulary when persisting into app-private caches or MediaStore.
+ */
+sealed interface GifExportTarget {
+    /** Human readable label surfaced in UI copy and logging. */
+    val displayName: String
+
+    /** File name applied to cached outputs within the app sandbox. */
+    val cacheFileName: String
+
+    /**
+     * File name persisted to MediaStore. The suffix always includes the
+     * ".gif" extension for downstream apps to infer the MIME type.
+     */
+    val mediaStoreFileName: String
+
+    /**
+     * Downloads relative path used when inserting into MediaStore. The same
+     * subdirectory is reused for all exports so users can find the outputs in
+     * one folder.
+     */
+    val downloadsRelativePath: String
+
+    companion object {
+        const val MIME_TYPE_GIF: String = "image/gif"
+        const val DOWNLOADS_SUBDIRECTORY: String = "GifVision"
+    }
+
+    /** Stream level preview generated from FFmpeg rendering. */
+    data class StreamPreview(val streamId: StreamId) : GifExportTarget {
+        override val displayName: String = "${streamId.displayName} preview"
+        override val cacheFileName: String =
+            "layer${streamId.layer.index}_stream_${streamId.channel.name.lowercase(Locale.US)}.gif"
+        override val mediaStoreFileName: String =
+            "layer${streamId.layer.index}_${streamId.channel.name.lowercase(Locale.US)}_preview.gif"
+        override val downloadsRelativePath: String = DOWNLOADS_SUBDIRECTORY
+    }
+
+    /** Layer blend produced after combining the A & B streams. */
+    data class LayerBlend(val layerId: LayerId) : GifExportTarget {
+        override val displayName: String = "${layerId.displayName} blend"
+        override val cacheFileName: String = "layer${layerId.index}_blend.gif"
+        override val mediaStoreFileName: String = "layer${layerId.index}_blend.gif"
+        override val downloadsRelativePath: String = DOWNLOADS_SUBDIRECTORY
+    }
+
+    /** Final master blend that merges both layer composites. */
+    data object MasterBlend : GifExportTarget {
+        override val displayName: String = "Master blend"
+        override val cacheFileName: String = "master_blend.gif"
+        override val mediaStoreFileName: String = "master_blend.gif"
+        override val downloadsRelativePath: String = DOWNLOADS_SUBDIRECTORY
+    }
+}

--- a/feature/home/src/main/kotlin/com/example/giffer2/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/example/giffer2/feature/home/HomeUiState.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.example.gifvision.BlendMode
 import com.example.gifvision.ClipMetadata
 import com.example.gifvision.EffectSettings
+import com.example.gifvision.GifExportTarget
 import com.example.gifvision.GifReference
 import com.example.gifvision.GifWorkProgress
 import com.example.gifvision.LayerId
@@ -30,8 +31,9 @@ data class HomeUiState(
     val hasErrors: Boolean = false,
     val showWarningBadge: Boolean = false,
     val showErrorBadge: Boolean = false,
-    val pendingSaveRequest: ExportTarget? = null,
-    val pendingShareRequest: ExportTarget? = null
+    val pendingSaveRequest: GifExportTarget? = null,
+    val pendingShareRequest: GifExportTarget? = null,
+    val activeExports: Set<GifExportTarget> = emptySet()
 ) {
     companion object {
         /** Factory used for previews/tests so callers get deterministic state. */
@@ -163,16 +165,4 @@ data class MasterBlendUiState(
 ) {
     val isGenerating: Boolean
         get() = progress?.let { it.stage != GifWorkProgress.Stage.COMPLETED && it.percent < 100 } ?: false
-}
-
-/**
- * Targets that can trigger save/share actions from the UI.  The view model
- * updates [HomeUiState.pendingSaveRequest] or
- * [HomeUiState.pendingShareRequest] with one of these targets so higher layers
- * can react to the intent exactly once.
- */
-sealed interface ExportTarget {
-    data class Stream(val streamId: StreamId) : ExportTarget
-    data class LayerBlend(val layerId: LayerId) : ExportTarget
-    data object MasterBlend : ExportTarget
 }

--- a/feature/home/src/main/kotlin/com/example/giffer2/feature/home/ShareSheetLauncher.kt
+++ b/feature/home/src/main/kotlin/com/example/giffer2/feature/home/ShareSheetLauncher.kt
@@ -1,0 +1,60 @@
+package com.example.giffer2.feature.home
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.example.giffer2.feature.home.processing.GifProcessingCoordinator
+
+/**
+ * Helper that prepares and launches a share sheet for GIF exports.
+ */
+class ShareSheetLauncher(private val context: Context) {
+    /**
+     * Launches an ACTION_SEND intent. Returns true if an activity was started
+     * successfully, false if no compatible activity was available.
+     */
+    fun launch(result: GifProcessingCoordinator.ShareResult): Boolean {
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            putExtra(Intent.EXTRA_SUBJECT, result.displayName)
+            val uri = result.uri
+            if (uri.scheme.equals("data", ignoreCase = true)) {
+                type = "text/plain"
+                extractBase64Payload(uri)?.let { payload ->
+                    putExtra(Intent.EXTRA_TEXT, payload)
+                } ?: putExtra(Intent.EXTRA_TEXT, uri.toString())
+            } else {
+                type = result.mimeType
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            if (context !is Activity) {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        }
+
+        return try {
+            context.startActivity(Intent.createChooser(shareIntent, result.displayName))
+            true
+        } catch (error: ActivityNotFoundException) {
+            false
+        }
+    }
+
+    private fun extractBase64Payload(uri: Uri): String? {
+        val payload = uri.schemeSpecificPart ?: return null
+        val marker = "base64,"
+        val index = payload.indexOf(marker)
+        return if (index >= 0) payload.substring(index + marker.length) else payload
+    }
+}
+
+@Composable
+fun rememberShareSheetLauncher(): ShareSheetLauncher {
+    val context = LocalContext.current
+    return remember(context) { ShareSheetLauncher(context) }
+}


### PR DESCRIPTION
## Summary
- add GifExportTarget to centralize deterministic naming for streams, layer blends, and the master blend
- extend GifProcessingCoordinator to copy GIFs into MediaStore downloads and expose share-ready URIs backed by FileProvider
- update the home UI to run export flows with toasts, disabled buttons during work, and a reusable share sheet launcher
- register FileProvider paths so cached GIFs can be shared outside the app

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f9b6766c8320a03a5529abaf7ef1